### PR TITLE
feat: improve default style of roi

### DIFF
--- a/src/components/api/RoiList.tsx
+++ b/src/components/api/RoiList.tsx
@@ -50,7 +50,7 @@ function defaultGetStyle<TData = unknown>(
     style: {
       color: 'white',
       backgroundColor: 'black',
-      opacity: selected ? 0.2 : 0.5,
+      opacity: selected ? 0.5 : 0.3,
     },
   };
 }


### PR DESCRIPTION
close: https://github.com/zakodium-oss/react-roi/issues/53

selected is now 0.5 and non-selected 0.3