### PR TITLE
feat: lifecycle callbacks and default roi data

### DIFF
--- a/src/components/box/RoiBox.tsx
+++ b/src/components/box/RoiBox.tsx
@@ -57,6 +57,7 @@ function RoiBoxInternal(props: RoiBoxProps): JSX.Element {
           width: box.width,
           height: box.height,
           pointerEvents: 'none',
+          whiteSpace: 'pre',
         }}
       >
         {renderLabel(roi, {

--- a/src/components/container/ContainerComponent.tsx
+++ b/src/components/container/ContainerComponent.tsx
@@ -2,6 +2,7 @@ import useResizeObserver from '@react-hook/resize-observer';
 import {
   CSSProperties,
   Dispatch,
+  JSX,
   MutableRefObject,
   ReactNode,
   useEffect,
@@ -47,6 +48,7 @@ interface ContainerProps<TData = unknown> {
   onDrawFinish?: OnFinishDrawCallback<TData>;
   onMoveFinish?: OnFinishUpdateCallback<TData>;
   onResizeFinish?: OnFinishUpdateCallback<TData>;
+  getNewRoiData?: () => TData;
 }
 
 export function ContainerComponent<TData = unknown>(
@@ -73,12 +75,19 @@ export function ContainerComponent<TData = unknown>(
   const onDrawFinishRef = useRef(props.onDrawFinish);
   const onMoveFinish = useRef(props.onMoveFinish);
   const onResizeFinish = useRef(props.onResizeFinish);
+  const getNewRoiData = useRef(props.getNewRoiData);
 
   useEffect(() => {
     onDrawFinishRef.current = props.onDrawFinish;
     onMoveFinish.current = props.onMoveFinish;
     onResizeFinish.current = props.onResizeFinish;
-  }, [props.onDrawFinish, props.onResizeFinish, props.onMoveFinish]);
+    getNewRoiData.current = props.getNewRoiData;
+  }, [
+    props.onDrawFinish,
+    props.onResizeFinish,
+    props.onMoveFinish,
+    props.getNewRoiData,
+  ]);
 
   useResizeObserver(ref, (entry) => {
     const { width, height } = entry.contentRect;
@@ -193,6 +202,7 @@ export function ContainerComponent<TData = unknown>(
               isPanZooming: event.altKey,
               lockPan,
               noUnselection,
+              data: getNewRoiData.current?.(),
             },
           });
         }}

--- a/src/components/container/RoiContainer.tsx
+++ b/src/components/container/RoiContainer.tsx
@@ -41,6 +41,10 @@ export interface RoiContainerProps<TData = unknown> {
    * @returns true if the creation of the ROI should be cancelled, false otherwise.
    */
   onResizeFinish?: OnFinishUpdateCallback<TData>;
+  /**
+   * Get the data of a new ROI as it is being drawn.
+   */
+  getNewRoiData?: () => TData;
 }
 
 export type OnFinishDrawCallback<TData = unknown> = (

--- a/src/components/container/RoiContainer.tsx
+++ b/src/components/container/RoiContainer.tsx
@@ -1,37 +1,64 @@
 import useResizeObserver from '@react-hook/resize-observer';
-import { CSSProperties, ReactNode } from 'react';
+import { CSSProperties, JSX, MutableRefObject, ReactNode } from 'react';
 
+import { UpdateData } from '../../hooks/useActions';
 import { usePanZoom } from '../../hooks/usePanZoom';
 import { useRoiDispatch } from '../../hooks/useRoiDispatch';
+import { CommittedRoi } from '../../types/Roi';
 
 import { ContainerComponent } from './ContainerComponent';
 
-export interface RoiContainerProps {
-  target?: JSX.Element;
+export interface RoiContainerProps<TData = unknown> {
+  target: JSX.Element;
   children?: ReactNode;
   style?: CSSProperties;
   className?: string;
   id?: string;
-  targetRef?: React.MutableRefObject<undefined>;
+  targetRef?: MutableRefObject<undefined>;
   lockZoom?: boolean;
   lockPan?: boolean;
   /**
    * If true, the user won't be able to unselect the current ROI by clicking on the container
    */
   noUnselection?: boolean;
+  /**
+   * Called right before the ROI has finished being drawn.
+   If specified, it becomes responsible for creating the ROI based on the data provided in the arguments.
+   * @param roi The ROI that was just drawn. The position and size are already normalized and bounded to the target size.
+   */
+  onDrawFinish?: OnFinishDrawCallback<TData>;
+  /**
+   * Called right before the ROI has finished moving.
+   * If specified, it becomes responsible for updating the ROI based on the data provided in the arguments.
+   * @param roi The ROI that was just moved. The position and size are already normalized and bounded to the target size.
+   * @returns true if the creation of the ROI should be cancelled, false otherwise.
+   */
+  onMoveFinish?: OnFinishUpdateCallback<TData>;
+  /**
+   * Called right before the ROI has finished resizing.
+   * If specified, it becomes responsible for updating the ROI based on the data provided in the arguments.
+   * @param roi The ROI that was just resized. The position and size are already normalized and bounded to the target size.
+   * @returns true if the creation of the ROI should be cancelled, false otherwise.
+   */
+  onResizeFinish?: OnFinishUpdateCallback<TData>;
 }
 
-export function RoiContainer(props: RoiContainerProps) {
+export type OnFinishDrawCallback<TData = unknown> = (
+  roi: CommittedRoi<TData>,
+) => void;
+export type OnFinishUpdateCallback<TData = unknown> = (
+  selectedRoiId: string,
+  roi: UpdateData<TData>,
+) => void;
+
+export function RoiContainer<TData = unknown>(props: RoiContainerProps<TData>) {
   const {
-    target,
     targetRef,
     children,
     style,
-    className,
-    id,
-    noUnselection,
     lockZoom = false,
     lockPan = false,
+    ...otherProps
   } = props;
 
   const roiDispatch = useRoiDispatch();
@@ -51,14 +78,11 @@ export function RoiContainer(props: RoiContainerProps) {
     <ContainerComponent
       lockZoom={lockZoom}
       lockPan={lockPan}
-      id={id}
-      target={target}
-      noUnselection={noUnselection}
       style={{
         ...style,
         visibility: panZoom.isReady ? 'visible' : 'hidden',
       }}
-      className={className}
+      {...otherProps}
     >
       {children}
     </ContainerComponent>

--- a/src/context/RoiProvider.tsx
+++ b/src/context/RoiProvider.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useMemo, useReducer, useRef } from 'react';
+import { ReactNode, useEffect, useMemo, useReducer, useRef } from 'react';
 
 import type { ResizeStrategy, RoiMode, RoiState } from '..';
 import { CommittedRoi } from '../types/Roi';
@@ -12,6 +12,7 @@ import {
   roiDispatchContext,
   roisContext,
   roiStateContext,
+  roiStateRefContext,
 } from './contexts';
 import { ReactRoiState, roiReducer } from './roiReducer';
 import { initialSize, isSizeObserved } from './updaters/initialPanZoom';
@@ -99,7 +100,12 @@ export function RoiProvider<T>(props: RoiProviderProps<T>) {
   });
 
   const [state, dispatch] = useReducer(roiReducer, roiInitialState);
+  const stateRef = useRef(state);
   const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
 
   const {
     rois,
@@ -132,18 +138,20 @@ export function RoiProvider<T>(props: RoiProviderProps<T>) {
   }, [panZoom, initialPanZoom, targetSize, containerSize]);
 
   return (
-    <roiContainerRefContext.Provider value={containerRef}>
-      <panZoomContext.Provider value={panzoomContextValue}>
-        <roiDispatchContext.Provider value={dispatch}>
-          <roisContext.Provider value={rois}>
-            <committedRoisContext.Provider value={committedRois}>
-              <roiStateContext.Provider value={roiState}>
-                {children}
-              </roiStateContext.Provider>
-            </committedRoisContext.Provider>
-          </roisContext.Provider>
-        </roiDispatchContext.Provider>
-      </panZoomContext.Provider>
-    </roiContainerRefContext.Provider>
+    <roiStateRefContext.Provider value={stateRef}>
+      <roiContainerRefContext.Provider value={containerRef}>
+        <panZoomContext.Provider value={panzoomContextValue}>
+          <roiDispatchContext.Provider value={dispatch}>
+            <roisContext.Provider value={rois}>
+              <committedRoisContext.Provider value={committedRois}>
+                <roiStateContext.Provider value={roiState}>
+                  {children}
+                </roiStateContext.Provider>
+              </committedRoisContext.Provider>
+            </roisContext.Provider>
+          </roiDispatchContext.Provider>
+        </panZoomContext.Provider>
+      </roiContainerRefContext.Provider>
+    </roiStateRefContext.Provider>
   );
 }

--- a/src/context/contexts.ts
+++ b/src/context/contexts.ts
@@ -1,9 +1,9 @@
-import { createContext, Dispatch, MutableRefObject } from 'react';
+import { createContext, Dispatch, MutableRefObject, RefObject } from 'react';
 
 import { PanZoom, RoiState, Size } from '..';
 import { CommittedRoi, Roi } from '../types/Roi';
 
-import type { RoiReducerAction } from './roiReducer';
+import { ReactRoiState, RoiReducerAction } from './roiReducer';
 import { initialSize } from './updaters/initialPanZoom';
 
 export const roiStateContext = createContext<RoiState | null>(null);
@@ -55,3 +55,6 @@ export const panZoomContext = createContext<PanZoomContext>({
   },
   isReady: false,
 });
+
+export const roiStateRefContext =
+  createContext<RefObject<ReactRoiState> | null>(null);

--- a/src/context/roiReducer.tsx
+++ b/src/context/roiReducer.tsx
@@ -1,4 +1,5 @@
 import { produce } from 'immer';
+import type { MouseEvent as ReactMouseEvent } from 'react';
 
 import { PanZoom, ResizeStrategy, RoiAction, RoiMode, Size } from '..';
 import { CommittedRoi, Roi } from '../types/Roi';
@@ -90,11 +91,12 @@ export interface ZoomPayload {
 }
 
 export interface StartDrawPayload {
-  event: MouseEvent | React.MouseEvent;
+  event: MouseEvent | ReactMouseEvent;
   containerBoundingRect: DOMRect;
   isPanZooming: boolean;
   noUnselection?: boolean;
   lockPan: boolean;
+  data?: unknown;
 }
 
 export interface StartResizePayload {

--- a/src/context/updaters/cancelAction.ts
+++ b/src/context/updaters/cancelAction.ts
@@ -4,9 +4,12 @@ import { Roi } from '../../types/Roi';
 import { Box } from '../../types/utils';
 import { assert } from '../../utilities/assert';
 import { denormalizeBox } from '../../utilities/coordinates';
-import { ReactRoiState } from '../roiReducer';
+import { CancelActionPayload, ReactRoiState } from '../roiReducer';
 
-export function cancelAction(draft: Draft<ReactRoiState>) {
+export function cancelAction(
+  draft: Draft<ReactRoiState>,
+  payload: CancelActionPayload,
+) {
   const rois = draft.rois.filter((roi) => roi.action.type !== 'idle');
 
   if (rois.length === 0) {
@@ -18,7 +21,11 @@ export function cancelAction(draft: Draft<ReactRoiState>) {
   if (roi.action.type === 'drawing') {
     const roiIndex = draft.rois.findIndex((r) => r.id === roi.id);
     draft.rois.splice(roiIndex, 1);
-    draft.selectedRoi = null;
+    if (payload.noUnselection) {
+      draft.selectedRoi = roi.action.previousSelectedRoi;
+    } else {
+      draft.selectedRoi = undefined;
+    }
   } else {
     // Revert to the previous state
     const committedRoi = draft.committedRois.find((r) => r.id === roi.id);

--- a/src/context/updaters/roi.ts
+++ b/src/context/updaters/roi.ts
@@ -5,10 +5,16 @@ import { CommittedRoi, Roi } from '../../types/Roi';
 import { denormalizeBox, normalizeBox } from '../../utilities/coordinates';
 import { ReactRoiState } from '../roiReducer';
 
-function boundRoi<T extends CommittedBox>(
+export type BoundStrategy = 'move' | 'resize';
+
+export function boundRoi<T extends CommittedBox>(
   committedBox: T,
   targetSize: Size,
-  actionType: Roi['action']['type'],
+  /**
+   * Strategy to bound the ROI box. If `move`, the ROI box will be moved so that it fits inside the target.
+   * If `resize`, the ROI box will be resized so that it fits inside the target.
+   */
+  strategy: BoundStrategy,
 ): CommittedBox {
   // Bound points and recalculate width and height
   const result: CommittedBox = {
@@ -18,7 +24,7 @@ function boundRoi<T extends CommittedBox>(
     height: committedBox.height,
   };
 
-  if (actionType === 'drawing' || actionType === 'resizing') {
+  if (strategy === 'resize') {
     if (result.x < 0) {
       result.width += result.x;
       result.x = 0;
@@ -61,7 +67,7 @@ export function updateCommitedRoiPosition(
   const normalizedBox = boundRoi(
     normalizeBox(roi),
     draft.targetSize,
-    roi.action.type,
+    roi.action.type === 'moving' ? 'move' : 'resize',
   );
   if (normalizedBox.height === 0 || normalizedBox.width === 0) {
     // Revert changes since the ROI is no longer visible

--- a/src/context/updaters/startDraw.ts
+++ b/src/context/updaters/startDraw.ts
@@ -13,7 +13,7 @@ import { ReactRoiState, StartDrawPayload } from '../roiReducer';
  */
 export function startDraw(draft: ReactRoiState, payload: StartDrawPayload) {
   const { event, containerBoundingRect, noUnselection, lockPan } = payload;
-  const emptyRoi = createRoi(crypto.randomUUID(), draft.targetSize);
+  const emptyRoi = createRoi(crypto.randomUUID());
 
   if (payload.isPanZooming && !lockPan) {
     draft.action = 'panning';

--- a/src/context/updaters/startDraw.ts
+++ b/src/context/updaters/startDraw.ts
@@ -34,6 +34,7 @@ export function startDraw(draft: ReactRoiState, payload: StartDrawPayload) {
     case 'draw': {
       const roi: Roi = {
         ...emptyRoi,
+        data: payload.data,
         action: {
           type: 'drawing',
           xAxisCorner: 'left',
@@ -45,8 +46,6 @@ export function startDraw(draft: ReactRoiState, payload: StartDrawPayload) {
         y1: y,
         x2: x,
         y2: y,
-
-        data: undefined,
       };
       draft.selectedRoi = roi.id;
       draft.rois.push(roi);

--- a/src/hooks/useActions.ts
+++ b/src/hooks/useActions.ts
@@ -1,24 +1,31 @@
-import { useMemo } from 'react';
+import { KeyboardEvent as ReactKeyboardEvent, useMemo } from 'react';
 
+import { CancelActionPayload } from '../context/roiReducer';
 import { CommittedRoi } from '../types/Roi';
 import { RoiMode } from '../types/utils';
 
 import { useRoiContainerRef } from './useRoiContainerRef';
 import { useRoiDispatch } from './useRoiDispatch';
 
-export type UpdateData<T = unknown> = Partial<Omit<CommittedRoi<T>, 'id'>>;
-export function useActions<T = unknown>() {
+export type UpdateData<TData = unknown> = Partial<
+  Omit<CommittedRoi<TData>, 'id'>
+>;
+export function useActions<TData = unknown>() {
   const roiDispatch = useRoiDispatch();
   const ref = useRoiContainerRef();
 
   return useMemo(() => {
     return {
-      cancelAction: (event: KeyboardEvent) => {
+      cancelAction: (
+        event: KeyboardEvent | ReactKeyboardEvent,
+        options: CancelActionPayload,
+      ) => {
         event.preventDefault();
 
         if (event.isTrusted) {
           roiDispatch({
             type: 'CANCEL_ACTION',
+            payload: options,
           });
         }
       },
@@ -36,13 +43,13 @@ export function useActions<T = unknown>() {
           },
         });
       },
-      createRoi: (roi: CommittedRoi<T>) => {
+      createRoi: (roi: CommittedRoi<TData>) => {
         roiDispatch({
           type: 'CREATE_ROI',
           payload: roi,
         });
       },
-      updateRoi: (selectedRoi: string, updatedData: UpdateData<T>) => {
+      updateRoi: (selectedRoi: string, updatedData: UpdateData<TData>) => {
         roiDispatch({
           type: 'UPDATE_ROI',
           payload: { ...updatedData, id: selectedRoi },

--- a/src/hooks/useCurrentState.ts
+++ b/src/hooks/useCurrentState.ts
@@ -1,0 +1,12 @@
+import { RefObject, useContext } from 'react';
+
+import { roiStateRefContext } from '../context/contexts';
+import { ReactRoiState } from '../context/roiReducer';
+
+export function useCurrentState<T>() {
+  const context = useContext(roiStateRefContext);
+  if (context === null) {
+    throw new Error('useStateRef must be used within a RoiProvider');
+  }
+  return context as RefObject<ReactRoiState<T>>;
+}

--- a/stories/hooks/useActions/add.stories.tsx
+++ b/stories/hooks/useActions/add.stories.tsx
@@ -1,4 +1,5 @@
 import { Meta } from '@storybook/react';
+import { useState } from 'react';
 
 import {
   RoiContainer,
@@ -44,6 +45,66 @@ export function AddROI() {
         </RoiContainer>
         <CommittedRoisButton />
       </Layout>
+    </RoiProvider>
+  );
+}
+
+interface CountData {
+  moveCount: number;
+  resizeCount: number;
+  count: number;
+}
+
+function OnLifecycleHooksInternal() {
+  const { createRoi, updateRoi } = useActions<CountData>();
+  const [count, setCount] = useState(0);
+
+  return (
+    <Layout>
+      <RoiContainer<CountData>
+        target={<TargetImage id="story-image" src="/barbara.jpg" />}
+        onDrawFinish={(roi) => {
+          createRoi({
+            ...roi,
+            data: { moveCount: 0, count: count + 1, resizeCount: 0 },
+          });
+          setCount(count + 1);
+        }}
+        onMoveFinish={(selectedRoi, roi) => {
+          updateRoi(selectedRoi, {
+            ...roi,
+            data: {
+              ...roi.data,
+              moveCount: roi.data.moveCount + 1,
+            },
+          });
+        }}
+        onResizeFinish={(selectedRoi, roi) => {
+          updateRoi(selectedRoi, {
+            ...roi,
+            data: {
+              ...roi.data,
+              resizeCount: roi.data.resizeCount + 1,
+            },
+          });
+        }}
+      >
+        <RoiList<CountData>
+          renderLabel={(roi) => {
+            if (!roi.data) return null;
+            return `ROI ${roi.data?.count || 0}\nMoved: ${roi.data?.moveCount || 0}\nResized: ${roi.data?.resizeCount || 0}`;
+          }}
+        />
+      </RoiContainer>
+      <CommittedRoisButton />
+    </Layout>
+  );
+}
+
+export function LifecycleHooks() {
+  return (
+    <RoiProvider>
+      <OnLifecycleHooksInternal />
     </RoiProvider>
   );
 }

--- a/stories/misc/new-roi-data.stories.tsx
+++ b/stories/misc/new-roi-data.stories.tsx
@@ -1,0 +1,43 @@
+import { Meta } from '@storybook/react';
+import { useState } from 'react';
+
+import { RoiContainer, RoiList, RoiProvider, TargetImage } from '../../src';
+import { Layout } from '../utils/Layout';
+
+export default {
+  title: 'Misc',
+} as Meta;
+
+export function NewRoiData() {
+  const [selectedColor, setSelectedColor] = useState('blue');
+  return (
+    <RoiProvider>
+      <Layout>
+        <select
+          value={selectedColor}
+          onChange={(event) => setSelectedColor(event.target.value)}
+        >
+          <option value="blue">Blue</option>
+          <option value="red">Red</option>
+          <option value="green">Green</option>
+        </select>
+        <RoiContainer<string>
+          getNewRoiData={() => {
+            return selectedColor;
+          }}
+          target={<TargetImage id="story-image" src="/barbara.jpg" />}
+        >
+          <RoiList<string>
+            getStyle={(roi) => {
+              return {
+                rectAttributes: {
+                  fill: roi.data,
+                },
+              };
+            }}
+          />
+        </RoiContainer>
+      </Layout>
+    </RoiProvider>
+  );
+}

--- a/stories/misc/shortcuts.stories.tsx
+++ b/stories/misc/shortcuts.stories.tsx
@@ -30,7 +30,7 @@ export function Shortcuts() {
   useKbsGlobal([
     {
       shortcut: ['Escape'],
-      handler: cancelAction,
+      handler: (event) => cancelAction(event, { noUnselection: false }),
     },
   ]);
 

--- a/stories/utils/initialRois.ts
+++ b/stories/utils/initialRois.ts
@@ -12,7 +12,7 @@ export function getInitialRois<T>(
       y: 0,
       width: Math.floor(0.2 * width),
       height: Math.floor(0.2 * height),
-      label: 'Roi label A',
+      label: 'Roi A',
       data,
     },
     {
@@ -21,7 +21,7 @@ export function getInitialRois<T>(
       y: 0,
       width: Math.floor(0.2 * width),
       height: Math.floor(0.2 * height),
-      label: 'Roi label B',
+      label: 'Roi B',
       data,
     },
     {
@@ -30,7 +30,7 @@ export function getInitialRois<T>(
       y: Math.floor(0.5 * height),
       width: Math.floor(0.2 * width),
       height: Math.floor(0.1 * height),
-      label: 'Roi label C',
+      label: 'Roi C',
       data,
     },
   ];


### PR DESCRIPTION
- feat: on create, move and resize hooks
- feat: add getNewRoiData prop to initialize roi data on draw
- feat: preserve spaces in label
