### PR TITLE
chore: use strict types

### DIFF
--- a/src/components/RoiList.tsx
+++ b/src/components/RoiList.tsx
@@ -29,16 +29,21 @@ export interface CustomRoiStyle {
   renderCustomPattern?: () => JSX.Element;
 }
 
+export type GetStyleCallback<TData = unknown> = (
+  roi: Roi<TData>,
+  roiAdditionalState: RoiAdditionalCallbackState,
+) => CustomRoiStyle;
+
+export type GetReadOnlyCallback<TData = unknown> = (roi: Roi<TData>) => boolean;
+export type RenderLabelCallback<TData = unknown> = (
+  roi: Roi<TData>,
+  roiAdditionalState: RoiAdditionalCallbackState,
+) => ReactNode;
+
 export interface RoiListProps<TData = unknown> {
-  getStyle?: (
-    roi: Roi<TData>,
-    roiAdditionalState: RoiAdditionalCallbackState,
-  ) => CustomRoiStyle;
-  getReadOnly?: (roi: Roi<TData>) => boolean;
-  renderLabel?: (
-    roi: Roi<TData>,
-    roiAdditionalState: RoiAdditionalCallbackState,
-  ) => ReactNode;
+  getStyle?: GetStyleCallback<TData>;
+  getReadOnly?: GetReadOnlyCallback<TData>;
+  renderLabel?: RenderLabelCallback<TData>;
 }
 
 export function RoiList<TData = unknown>(props: RoiListProps<TData>) {
@@ -62,9 +67,9 @@ export function RoiList<TData = unknown>(props: RoiListProps<TData>) {
         <RoiBox
           key={roi.id}
           roi={roi}
-          getStyle={getStyle}
-          renderLabel={renderLabel}
-          getReadOnly={getReadOnly}
+          getStyle={getStyle as GetStyleCallback}
+          renderLabel={renderLabel as RenderLabelCallback}
+          getReadOnly={getReadOnly as GetReadOnlyCallback}
           isSelected={roi.id === selectedRoi}
         />
       ))}
@@ -72,7 +77,7 @@ export function RoiList<TData = unknown>(props: RoiListProps<TData>) {
   );
 }
 
-const defaultGetStyle: RoiListProps['getStyle'] = (roi, state) => {
+const defaultGetStyle: GetStyleCallback = (roi, state) => {
   return {
     rectAttributes: {
       fill: state.isReadOnly
@@ -85,10 +90,7 @@ const defaultGetStyle: RoiListProps['getStyle'] = (roi, state) => {
   };
 };
 
-const defaultRenderLabel: RoiListProps['renderLabel'] = (
-  roi,
-  { zoomScale },
-) => {
+const defaultRenderLabel: RenderLabelCallback = (roi, { zoomScale }) => {
   return (
     <div
       style={{

--- a/src/components/box/Box.tsx
+++ b/src/components/box/Box.tsx
@@ -1,6 +1,6 @@
 import { CSSProperties } from 'react';
 
-import { RoiAction, RoiListProps, RoiMode, useRoiState } from '../..';
+import { GetStyleCallback, RoiAction, RoiMode, useRoiState } from '../..';
 import { useIsKeyDown } from '../../hooks/useIsKeyDown';
 import { useLockContext } from '../../hooks/useLockContext';
 import { usePanZoom } from '../../hooks/usePanZoom';
@@ -17,7 +17,7 @@ export interface BoxAnnotationProps {
   style?: CSSProperties;
   className?: string;
   isReadOnly: boolean;
-  getStyle: RoiListProps['getStyle'];
+  getStyle: GetStyleCallback;
 }
 
 export function Box({

--- a/src/components/box/RoiBox.tsx
+++ b/src/components/box/RoiBox.tsx
@@ -1,6 +1,10 @@
-import { memo, useEffect } from 'react';
+import { JSX, memo, useEffect } from 'react';
 
-import { RoiListProps } from '../..';
+import {
+  GetReadOnlyCallback,
+  GetStyleCallback,
+  RenderLabelCallback,
+} from '../..';
 import { usePanZoom } from '../../hooks/usePanZoom';
 import { useRoiDispatch } from '../../hooks/useRoiDispatch';
 import { Roi } from '../../types/Roi';
@@ -12,9 +16,9 @@ import { roiToFloorBox } from './util';
 interface RoiBoxProps {
   roi: Roi;
   isSelected: boolean;
-  getStyle: RoiListProps['getStyle'];
-  getReadOnly: RoiListProps['getReadOnly'];
-  renderLabel: RoiListProps['renderLabel'];
+  getStyle: GetStyleCallback;
+  getReadOnly: GetReadOnlyCallback;
+  renderLabel: RenderLabelCallback;
 }
 
 function RoiBoxInternal(props: RoiBoxProps): JSX.Element {
@@ -22,7 +26,7 @@ function RoiBoxInternal(props: RoiBoxProps): JSX.Element {
 
   const panzoom = usePanZoom();
   const { id } = roi;
-  const isReadOnly = getReadOnly(roi);
+  const isReadOnly = getReadOnly?.(roi) || false;
 
   const scaledSizes = getScaledSizes(roi, panzoom);
   const roiDispatch = useRoiDispatch();

--- a/src/components/container/RoiContainer.tsx
+++ b/src/components/container/RoiContainer.tsx
@@ -1,9 +1,7 @@
-import useResizeObserver from '@react-hook/resize-observer';
-import { CSSProperties, JSX, MutableRefObject, ReactNode } from 'react';
+import { CSSProperties, JSX, ReactNode } from 'react';
 
 import { UpdateData } from '../../hooks/useActions';
 import { usePanZoom } from '../../hooks/usePanZoom';
-import { useRoiDispatch } from '../../hooks/useRoiDispatch';
 import { CommittedRoi } from '../../types/Roi';
 
 import { ContainerComponent } from './ContainerComponent';
@@ -14,7 +12,6 @@ export interface RoiContainerProps<TData = unknown> {
   style?: CSSProperties;
   className?: string;
   id?: string;
-  targetRef?: MutableRefObject<undefined>;
   lockZoom?: boolean;
   lockPan?: boolean;
   /**
@@ -57,7 +54,6 @@ export type OnFinishUpdateCallback<TData = unknown> = (
 
 export function RoiContainer<TData = unknown>(props: RoiContainerProps<TData>) {
   const {
-    targetRef,
     children,
     style,
     lockZoom = false,
@@ -65,18 +61,7 @@ export function RoiContainer<TData = unknown>(props: RoiContainerProps<TData>) {
     ...otherProps
   } = props;
 
-  const roiDispatch = useRoiDispatch();
   const panZoom = usePanZoom();
-
-  useResizeObserver(targetRef, (data) => {
-    roiDispatch({
-      type: 'SET_SIZE',
-      payload: {
-        width: data.contentRect.width,
-        height: data.contentRect.height,
-      },
-    });
-  });
 
   return (
     <ContainerComponent

--- a/src/context/RoiProvider.tsx
+++ b/src/context/RoiProvider.tsx
@@ -48,8 +48,11 @@ interface RoiProviderProps<T> {
   initialConfig?: RoiProviderInitialConfig<T>;
 }
 
-type CreateInitialConfigParam<T> = Required<RoiProviderInitialConfig<T>> & {
+type CreateInitialConfigParam<T> = Required<
+  Omit<RoiProviderInitialConfig<T>, 'selectedRoiId'>
+> & {
   zoom: Required<RoiProviderInitialConfig<T>['zoom']>;
+  selectedRoiId?: string;
 };
 
 function createInitialState<T>(

--- a/src/context/contexts.ts
+++ b/src/context/contexts.ts
@@ -1,4 +1,4 @@
-import { createContext, Dispatch, MutableRefObject, RefObject } from 'react';
+import { createContext, Dispatch, RefObject } from 'react';
 
 import { PanZoom, RoiState, Size } from '..';
 import { CommittedRoi, Roi } from '../types/Roi';
@@ -26,7 +26,7 @@ export const committedRoisContext = createContext<CommittedRoi[] | null>(null);
 export const roisContext = createContext<Roi[] | null>(null);
 
 export const roiContainerRefContext =
-  createContext<MutableRefObject<HTMLDivElement> | null>(null);
+  createContext<RefObject<HTMLDivElement> | null>(null);
 
 export interface PanZoomContext {
   panZoom: PanZoom;

--- a/src/hooks/useActions.ts
+++ b/src/hooks/useActions.ts
@@ -30,7 +30,7 @@ export function useActions<TData = unknown>() {
         }
       },
       zoom: (factor: number) => {
-        if (!ref.current) return;
+        if (!ref?.current) return;
         const refBound = ref.current.getBoundingClientRect();
 
         roiDispatch({

--- a/src/hooks/useRoiState.ts
+++ b/src/hooks/useRoiState.ts
@@ -1,15 +1,9 @@
 import { useContext } from 'react';
 
-import { RoiState } from '..';
 import { roiStateContext } from '../context/contexts';
 
 export function useRoiState() {
-  /**
-   * selected roi
-   * ratio
-   * mode
-   */
-  const state = useContext<RoiState>(roiStateContext);
+  const state = useContext(roiStateContext);
   if (!state) {
     throw new Error('useRoiState must be used within a RoiProvider');
   }

--- a/src/hooks/useTargetRef.ts
+++ b/src/hooks/useTargetRef.ts
@@ -3,8 +3,8 @@ import { useRef } from 'react';
 
 import { useRoiDispatch } from './useRoiDispatch';
 
-export function useTargetRef() {
-  const targetRef = useRef();
+export function useTargetRef<T extends HTMLElement>() {
+  const targetRef = useRef<T>(null);
   const roiDispatch = useRoiDispatch();
   useResizeObserver(targetRef, (data) => {
     roiDispatch({

--- a/src/utilities/throttle.ts
+++ b/src/utilities/throttle.ts
@@ -1,5 +1,7 @@
+// @ts-expect-error too generic to type
 export function throttle(func, timeFrame) {
   let lastTime = 0;
+  // @ts-expect-error too generic to type
   return function throttled(...args) {
     const now = new Date().getTime();
     if (now - lastTime >= timeFrame) {

--- a/stories/hooks/useActions/add.stories.tsx
+++ b/stories/hooks/useActions/add.stories.tsx
@@ -8,6 +8,7 @@ import {
   TargetImage,
   useActions,
 } from '../../../src';
+import { assert } from '../../../src/utilities/assert';
 import { CommittedRoisButton } from '../../utils/CommittedRoisButton';
 import { Layout } from '../../utils/Layout';
 import { getInitialRois } from '../../utils/initialRois';
@@ -71,6 +72,7 @@ function OnLifecycleHooksInternal() {
           setCount(count + 1);
         }}
         onMoveFinish={(selectedRoi, roi) => {
+          assert(roi.data);
           updateRoi(selectedRoi, {
             ...roi,
             data: {
@@ -80,6 +82,7 @@ function OnLifecycleHooksInternal() {
           });
         }}
         onResizeFinish={(selectedRoi, roi) => {
+          assert(roi.data);
           updateRoi(selectedRoi, {
             ...roi,
             data: {

--- a/stories/hooks/useActions/remove.stories.tsx
+++ b/stories/hooks/useActions/remove.stories.tsx
@@ -22,7 +22,14 @@ export function RemoveROI() {
     const { removeRoi } = useActions();
 
     return (
-      <button type="button" onClick={() => removeRoi(selectedRoi)}>
+      <button
+        type="button"
+        onClick={() => {
+          if (selectedRoi) {
+            removeRoi(selectedRoi);
+          }
+        }}
+      >
         Remove ROI
       </button>
     );

--- a/stories/hooks/useActions/update.stories.tsx
+++ b/stories/hooks/useActions/update.stories.tsx
@@ -30,7 +30,9 @@ export function Position() {
         updated.y = 0;
       }
 
-      updateRoi(selectedRoi, updated);
+      if (selectedRoi) {
+        updateRoi(selectedRoi, updated);
+      }
     }
 
     return (
@@ -66,7 +68,9 @@ export function Label() {
     const { updateRoi } = useActions();
 
     function onClick() {
-      updateRoi(selectedRoi, { label: 'Hello, World!' });
+      if (selectedRoi) {
+        updateRoi(selectedRoi, { label: 'Hello, World!' });
+      }
     }
 
     return (

--- a/stories/hooks/useCommittedRois/committed.stories.tsx
+++ b/stories/hooks/useCommittedRois/committed.stories.tsx
@@ -51,7 +51,9 @@ export function DisplayCommitedRois() {
           });
         }
 
-        writeCanvas(image, ref.current);
+        if (ref.current) {
+          writeCanvas(image, ref.current);
+        }
       });
   }, [rois]);
 

--- a/stories/misc/override.stories.tsx
+++ b/stories/misc/override.stories.tsx
@@ -9,6 +9,7 @@ import {
   useActions,
   useRoiState,
 } from '../../src';
+import { assert } from '../../src/utilities/assert';
 import { Layout } from '../utils/Layout';
 import { getInitialRois } from '../utils/initialRois';
 
@@ -76,13 +77,15 @@ export function WithIndividualStyles() {
     const { updateRoi } = useActions<CustomColorData>();
 
     function onClick() {
-      updateRoi(selectedRoi, {
-        data: {
-          textColor: 'white',
-          selectedBackgroundColor: 'yellowgreen',
-          backgroundColor: 'yellow',
-        },
-      });
+      if (selectedRoi) {
+        updateRoi(selectedRoi, {
+          data: {
+            textColor: 'white',
+            selectedBackgroundColor: 'yellowgreen',
+            backgroundColor: 'yellow',
+          },
+        });
+      }
     }
 
     return (
@@ -99,10 +102,9 @@ export function WithIndividualStyles() {
         <RoiContainer target={<TargetImage src="/barbara.jpg" />}>
           <RoiList<CustomColorData>
             getStyle={(roi, { isSelected }) => {
-              const {
-                data: { backgroundColor, selectedBackgroundColor },
-              } = roi;
-
+              const { data } = roi;
+              assert(data);
+              const { backgroundColor, selectedBackgroundColor } = data;
               return {
                 rectAttributes: {
                   fill: isSelected ? selectedBackgroundColor : backgroundColor,
@@ -158,7 +160,7 @@ function StripePattern(props: {
     pathAttributes?: Omit<SVGAttributes<SVGPathElement>, 'strokeWidth'>;
   };
   backgroundRectAttributes?: SVGAttributes<SVGRectElement>;
-}): ReactElement<{ id: string }, 'pattern'> {
+}): ReactElement<{ id: string }, 'pattern'> | null {
   if (!props.pattern) {
     return null;
   }

--- a/stories/utils/CommittedRoisButton.tsx
+++ b/stories/utils/CommittedRoisButton.tsx
@@ -32,7 +32,9 @@ export function CommittedRoisButton() {
           });
         }
 
-        writeCanvas(image, ref.current);
+        if (ref.current) {
+          writeCanvas(image, ref.current);
+        }
       });
   }, [rois, isShown]);
 

--- a/tests/TestComponent.tsx
+++ b/tests/TestComponent.tsx
@@ -54,7 +54,7 @@ export function TestComponent() {
 }
 
 function Target() {
-  const ref = useTargetRef();
+  const ref = useTargetRef<HTMLDivElement>();
   return (
     <div
       ref={ref}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "moduleResolution": "Node",
     "outDir": "lib",
     "sourceMap": true,
-    "strict": false,
+    "strict": true,
     "target": "ES2022",
     "types": ["vite/client", "node"],
     "skipLibCheck": true,


### PR DESCRIPTION
BREAKING CHANGES: remove targetRef prop from container. Should use the useTargetRef hook instead.

Closes: https://github.com/zakodium-oss/react-roi/issues/107
