### PR TITLE
feat: set initial zoom level and add onAfterZoomChange callback

### DIFF
--- a/src/components/container/RoiContainer.tsx
+++ b/src/components/container/RoiContainer.tsx
@@ -1,6 +1,6 @@
 import { CSSProperties, JSX, ReactNode } from 'react';
 
-import { UpdateData } from '../../hooks/useActions';
+import { Actions, UpdateData } from '../../hooks/useActions';
 import { usePanZoom } from '../../hooks/usePanZoom';
 import { CommittedRoi } from '../../types/Roi';
 
@@ -19,37 +19,19 @@ export interface RoiContainerProps<TData = unknown> {
    */
   noUnselection?: boolean;
   /**
-   * Called right before the ROI has finished being drawn.
-   If specified, it becomes responsible for creating the ROI based on the data provided in the arguments.
-   * @param roi The ROI that was just drawn. The position and size are already normalized and bounded to the target size.
-   */
-  onDrawFinish?: OnFinishDrawCallback<TData>;
-  /**
-   * Called right before the ROI has finished moving.
-   * If specified, it becomes responsible for updating the ROI based on the data provided in the arguments.
-   * @param roi The ROI that was just moved. The position and size are already normalized and bounded to the target size.
-   * @returns true if the creation of the ROI should be cancelled, false otherwise.
-   */
-  onMoveFinish?: OnFinishUpdateCallback<TData>;
-  /**
-   * Called right before the ROI has finished resizing.
-   * If specified, it becomes responsible for updating the ROI based on the data provided in the arguments.
-   * @param roi The ROI that was just resized. The position and size are already normalized and bounded to the target size.
-   * @returns true if the creation of the ROI should be cancelled, false otherwise.
-   */
-  onResizeFinish?: OnFinishUpdateCallback<TData>;
-  /**
    * Get the data of a new ROI as it is being drawn.
    */
   getNewRoiData?: () => TData;
 }
 
-export type OnFinishDrawCallback<TData = unknown> = (
+export type AfterDrawCallback<TData = unknown> = (
   roi: CommittedRoi<TData>,
+  actions: Actions,
 ) => void;
-export type OnFinishUpdateCallback<TData = unknown> = (
+export type AfterUpdateCallback<TData = unknown> = (
   selectedRoiId: string,
   roi: UpdateData<TData>,
+  actions: Actions,
 ) => void;
 
 export function RoiContainer<TData = unknown>(props: RoiContainerProps<TData>) {

--- a/src/context/contexts.ts
+++ b/src/context/contexts.ts
@@ -1,6 +1,12 @@
 import { createContext, Dispatch, RefObject } from 'react';
 
-import { PanZoom, RoiState, Size } from '..';
+import {
+  AfterDrawCallback,
+  AfterUpdateCallback,
+  PanZoom,
+  RoiState,
+  Size,
+} from '..';
 import { CommittedRoi, Roi } from '../types/Roi';
 
 import { ReactRoiState, RoiReducerAction } from './roiReducer';
@@ -58,3 +64,14 @@ export const panZoomContext = createContext<PanZoomContext>({
 
 export const roiStateRefContext =
   createContext<RefObject<ReactRoiState> | null>(null);
+
+export interface ActionCallbacks<TData = unknown> {
+  onAfterDraw?: AfterDrawCallback<TData>;
+  onAfterMove?: AfterUpdateCallback<TData>;
+  onAfterResize?: AfterUpdateCallback<TData>;
+  onAfterZoomChange?: (zoom: PanZoom) => void;
+}
+export const callbacksRefContext = createContext<RefObject<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ActionCallbacks<any>
+> | null>(null);

--- a/src/context/updaters/rectifyPanZoom.ts
+++ b/src/context/updaters/rectifyPanZoom.ts
@@ -7,6 +7,10 @@ import {
 } from '../../utilities/panZoom';
 import { ReactRoiState } from '../roiReducer';
 
+/**
+ * Apply a translation on the zoom so that it fits the constraints given by the zoomDomain configuration
+ * @param draft
+ */
 export function rectifyPanZoom(draft: Draft<ReactRoiState>) {
   const panZoom = computeTotalPanZoom(draft);
   const minX = applyTransformX(panZoom, 0);

--- a/src/hooks/useCallbacksRef.ts
+++ b/src/hooks/useCallbacksRef.ts
@@ -1,0 +1,11 @@
+import { RefObject, useContext } from 'react';
+
+import { ActionCallbacks, callbacksRefContext } from '../context/contexts';
+
+export default function useCallbacksRef<TData = unknown>() {
+  const callbacks = useContext(callbacksRefContext);
+  if (!callbacks) {
+    throw new Error('useCallbacksRef must be called within an RoiProvider');
+  }
+  return callbacks as RefObject<ActionCallbacks<TData>>;
+}

--- a/stories/hooks/useActions/add.stories.tsx
+++ b/stories/hooks/useActions/add.stories.tsx
@@ -56,58 +56,53 @@ interface CountData {
   count: number;
 }
 
-function OnLifecycleHooksInternal() {
-  const { createRoi, updateRoi } = useActions<CountData>();
+export function ActionHooks() {
   const [count, setCount] = useState(0);
-
   return (
-    <Layout>
-      <RoiContainer<CountData>
-        target={<TargetImage id="story-image" src="/barbara.jpg" />}
-        onDrawFinish={(roi) => {
-          createRoi({
-            ...roi,
-            data: { moveCount: 0, count: count + 1, resizeCount: 0 },
-          });
-          setCount(count + 1);
-        }}
-        onMoveFinish={(selectedRoi, roi) => {
-          assert(roi.data);
-          updateRoi(selectedRoi, {
-            ...roi,
-            data: {
-              ...roi.data,
-              moveCount: roi.data.moveCount + 1,
-            },
-          });
-        }}
-        onResizeFinish={(selectedRoi, roi) => {
-          assert(roi.data);
-          updateRoi(selectedRoi, {
-            ...roi,
-            data: {
-              ...roi.data,
-              resizeCount: roi.data.resizeCount + 1,
-            },
-          });
-        }}
-      >
-        <RoiList<CountData>
-          renderLabel={(roi) => {
-            if (!roi.data) return null;
-            return `ROI ${roi.data?.count || 0}\nMoved: ${roi.data?.moveCount || 0}\nResized: ${roi.data?.resizeCount || 0}`;
-          }}
-        />
-      </RoiContainer>
-      <CommittedRoisButton />
-    </Layout>
-  );
-}
-
-export function LifecycleHooks() {
-  return (
-    <RoiProvider>
-      <OnLifecycleHooksInternal />
+    <RoiProvider<CountData>
+      onAfterDraw={() => {
+        setCount(count + 1);
+      }}
+      onAfterMove={(selectedRoi, roi, { updateRoi }) => {
+        assert(roi.data);
+        updateRoi(selectedRoi, {
+          ...roi,
+          data: {
+            ...roi.data,
+            moveCount: roi.data.moveCount + 1,
+          },
+        });
+      }}
+      onAfterResize={(selectedRoi, roi, { updateRoi }) => {
+        assert(roi.data);
+        updateRoi(selectedRoi, {
+          ...roi,
+          data: {
+            ...roi.data,
+            resizeCount: roi.data.resizeCount + 1,
+          },
+        });
+      }}
+    >
+      <Layout>
+        <RoiContainer<CountData>
+          getNewRoiData={() => ({
+            moveCount: 0,
+            count: count + 1,
+            resizeCount: 0,
+          })}
+          target={<TargetImage id="story-image" src="/barbara.jpg" />}
+        >
+          <RoiList<CountData>
+            renderLabel={(roi) => {
+              if (roi.action.type === 'drawing') return null;
+              if (!roi.data) return null;
+              return `ROI ${roi.data?.count || 0}\nMoved: ${roi.data?.moveCount || 0}\nResized: ${roi.data?.resizeCount || 0}`;
+            }}
+          />
+        </RoiContainer>
+        <CommittedRoisButton />
+      </Layout>
     </RoiProvider>
   );
 }

--- a/stories/hooks/useActions/zoom.stories.tsx
+++ b/stories/hooks/useActions/zoom.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta } from '@storybook/react';
 
 import {
+  PanZoom,
   RoiContainer,
   RoiList,
   RoiProvider,
@@ -15,6 +16,7 @@ import { useResetOnChange } from '../../utils/useResetOnChange';
 export default {
   title: 'hooks/useActions',
   argTypes: {
+    onZoomChange: { action: 'zoom' },
     minZoom: {
       control: {
         type: 'number',
@@ -61,6 +63,7 @@ interface ZoomStoryProps {
   spaceAroundTarget: number;
   containerWidth: number;
   containerHeight: number;
+  onZoomChange: (zoom: PanZoom) => void;
 }
 
 export function Zoom({
@@ -69,6 +72,7 @@ export function Zoom({
   spaceAroundTarget,
   containerWidth,
   containerHeight,
+  onZoomChange,
 }: ZoomStoryProps) {
   const keyId = useResetOnChange([
     minZoom,
@@ -139,6 +143,7 @@ export function Zoom({
           spaceAroundTarget,
         },
       }}
+      onAfterZoomChange={onZoomChange}
     >
       <Layout fit>
         <ZoomButton />

--- a/stories/misc/initial-selected.stories.tsx
+++ b/stories/misc/initial-selected.stories.tsx
@@ -23,6 +23,22 @@ export function InitialSelectedRoi() {
   );
 }
 
+export function InitialZoomLevel() {
+  return (
+    <Layout>
+      <RoiProvider
+        initialConfig={{
+          zoom: { initial: { scale: 1.4, translation: [0, 0] } },
+        }}
+      >
+        <RoiContainer target={<TargetImage src="/barbara.jpg" />}>
+          <RoiList />
+        </RoiContainer>
+      </RoiProvider>
+    </Layout>
+  );
+}
+
 export function NoUnselection() {
   const initialRois = getInitialRois(320, 320);
   return (


### PR DESCRIPTION
BREAKING CHANGE: action callback defined as props of the provider instead of the container. Action callbacks like onDrawFinish no longer responsible for making the action.

Closes: https://github.com/zakodium-oss/react-roi/issues/105
