### PR TITLE
feat: add commitRoiBoxStrategy prop to opt in to rounding box properties

### DIFF
--- a/src/components/container/ContainerComponent.tsx
+++ b/src/components/container/ContainerComponent.tsx
@@ -305,6 +305,7 @@ function callPointerUpActionHooks(
             minNewRoiSize: options.minNewRoiSize,
           },
           'resize',
+          state.commitRoiBoxStrategy,
         );
         if (committedRoi) {
           callbacks.onAfterDraw(committedRoi, actions);
@@ -323,6 +324,7 @@ function callPointerUpActionHooks(
             minNewRoiSize: options.minNewRoiSize,
           },
           'move',
+          state.commitRoiBoxStrategy,
         );
         if (committedRoi && roiHasChanged(state, committedRoi)) {
           const { id, ...updateData } = committedRoi;
@@ -345,6 +347,7 @@ function callPointerUpActionHooks(
             minNewRoiSize: options.minNewRoiSize,
           },
           'resize',
+          state.commitRoiBoxStrategy,
         );
         if (committedRoi && roiHasChanged(state, committedRoi)) {
           const { id, ...updateData } = committedRoi;

--- a/src/components/container/ContainerComponent.tsx
+++ b/src/components/container/ContainerComponent.tsx
@@ -298,15 +298,12 @@ function callPointerUpActionHooks(
       if (callbacks.onAfterDraw) {
         const roi = state.rois.find((roi) => roi.action.type === 'drawing');
         assert(roi, 'An roi in the "drawing" state should exist while drawing');
-        const committedRoi = createCommittedRoiFromRoiIfValid(
-          roi,
-          {
-            targetSize: state.targetSize,
-            minNewRoiSize: options.minNewRoiSize,
-          },
-          'resize',
-          state.commitRoiBoxStrategy,
-        );
+        const committedRoi = createCommittedRoiFromRoiIfValid(roi, {
+          targetSize: state.targetSize,
+          minNewRoiSize: options.minNewRoiSize,
+          strategy: 'resize',
+          commitStrategy: state.commitRoiBoxStrategy,
+        });
         if (committedRoi) {
           callbacks.onAfterDraw(committedRoi, actions);
         }
@@ -317,15 +314,12 @@ function callPointerUpActionHooks(
       if (callbacks.onAfterMove) {
         const roi = state.rois.find((roi) => roi.action.type === 'moving');
         assert(roi, 'An roi in the "moving" state should exist while moving');
-        const committedRoi = createCommittedRoiFromRoiIfValid(
-          roi,
-          {
-            targetSize: state.targetSize,
-            minNewRoiSize: options.minNewRoiSize,
-          },
-          'move',
-          state.commitRoiBoxStrategy,
-        );
+        const committedRoi = createCommittedRoiFromRoiIfValid(roi, {
+          targetSize: state.targetSize,
+          minNewRoiSize: options.minNewRoiSize,
+          strategy: 'move',
+          commitStrategy: state.commitRoiBoxStrategy,
+        });
         if (committedRoi && roiHasChanged(state, committedRoi)) {
           const { id, ...updateData } = committedRoi;
           callbacks.onAfterMove(id, updateData, actions);
@@ -340,15 +334,12 @@ function callPointerUpActionHooks(
       if (callbacks.onAfterResize) {
         const roi = state.rois.find((roi) => roi.action.type === 'resizing');
         assert(roi, 'An roi in the "resizing" state should exist while moving');
-        const committedRoi = createCommittedRoiFromRoiIfValid(
-          roi,
-          {
-            targetSize: state.targetSize,
-            minNewRoiSize: options.minNewRoiSize,
-          },
-          'resize',
-          state.commitRoiBoxStrategy,
-        );
+        const committedRoi = createCommittedRoiFromRoiIfValid(roi, {
+          targetSize: state.targetSize,
+          minNewRoiSize: options.minNewRoiSize,
+          strategy: 'resize',
+          commitStrategy: state.commitRoiBoxStrategy,
+        });
         if (committedRoi && roiHasChanged(state, committedRoi)) {
           const { id, ...updateData } = committedRoi;
           callbacks.onAfterResize(id, updateData, actions);

--- a/src/context/RoiProvider.tsx
+++ b/src/context/RoiProvider.tsx
@@ -55,7 +55,7 @@ export interface RoiProviderInitialConfig<TData> {
   };
   resizeStrategy?: ResizeStrategy;
   /**
-   * How should the roi should be updated before being committed to the state when created / moved / resized / rotated.
+   * How should the roi be updated before committing it when created / moved / resized / rotated.
    * It affects the final values of `x`, `y`, `width`, and `height` box properties in the committed ROI.
    * 'exact' will keep the exact, non-rounded values. This results in floating point numbers in the box properties.
    * 'round' will try as much as possible to keep integers:

--- a/src/context/roiReducer.tsx
+++ b/src/context/roiReducer.tsx
@@ -24,6 +24,7 @@ interface ZoomDomain {
   max: number;
   spaceAroundTarget: number;
 }
+export type CommitBoxStrategy = 'exact' | 'round';
 
 export interface ReactRoiState<TData = unknown> {
   /**
@@ -35,6 +36,11 @@ export interface ReactRoiState<TData = unknown> {
    * Resize strategy
    */
   resizeStrategy: ResizeStrategy;
+
+  /**
+   * How box properties of the roi should be updated when committed.
+   */
+  commitRoiBoxStrategy: CommitBoxStrategy;
 
   /**
    * Identification of the selected object

--- a/src/context/updaters/endAction.ts
+++ b/src/context/updaters/endAction.ts
@@ -33,6 +33,7 @@ export function endAction(draft: ReactRoiState, payload: EndActionPayload) {
         minNewRoiSize: payload.minNewRoiSize,
       },
       'resize',
+      draft.commitRoiBoxStrategy,
     );
     if (newCommittedRoi === null) {
       // Roi is not valid, remove it

--- a/src/context/updaters/endAction.ts
+++ b/src/context/updaters/endAction.ts
@@ -26,15 +26,12 @@ export function endAction(draft: ReactRoiState, payload: EndActionPayload) {
     }
   } else {
     assert(roi.action.type === 'drawing');
-    const newCommittedRoi = createCommittedRoiFromRoiIfValid(
-      roi,
-      {
-        targetSize: draft.targetSize,
-        minNewRoiSize: payload.minNewRoiSize,
-      },
-      'resize',
-      draft.commitRoiBoxStrategy,
-    );
+    const newCommittedRoi = createCommittedRoiFromRoiIfValid(roi, {
+      targetSize: draft.targetSize,
+      minNewRoiSize: payload.minNewRoiSize,
+      strategy: 'resize',
+      commitStrategy: draft.commitRoiBoxStrategy,
+    });
     if (newCommittedRoi === null) {
       // Roi is not valid, remove it
       const index = draft.rois.findIndex((r) => r.id === roi.id);

--- a/src/context/updaters/roi.ts
+++ b/src/context/updaters/roi.ts
@@ -2,13 +2,17 @@ import { Draft } from 'immer';
 
 import { Box, CommittedBox, Size } from '../..';
 import { CommittedRoi, Roi, RoiAction } from '../../types/Roi';
-import { denormalizeBox, normalizeBox } from '../../utilities/coordinates';
+import {
+  commitBox,
+  denormalizeBox,
+  normalizeBox,
+} from '../../utilities/coordinates';
 import { getMBRBoundaries } from '../../utilities/rotate';
 import { ReactRoiState } from '../roiReducer';
 
 export type BoundStrategy = 'move' | 'resize';
 
-export function boundRoi<T extends CommittedBox>(
+export function boundBox<T extends CommittedBox>(
   committedBox: T,
   targetSize: Size,
   /**
@@ -85,8 +89,8 @@ export function updateCommittedRoiPosition(
   committedRoi: Draft<CommittedRoi>,
   roi: Draft<Roi>,
 ) {
-  const normalizedBox = boundRoi(
-    normalizeBox(roi),
+  const normalizedBox = boundBox(
+    commitBox(normalizeBox(roi), roi.action, draft.commitRoiBoxStrategy),
     draft.targetSize,
     // If rotating, use move since it does not change the overall size of the ROI
     boundStrategyMap[roi.action.type],

--- a/src/types/Roi.ts
+++ b/src/types/Roi.ts
@@ -1,8 +1,6 @@
 import { XCornerPosition, YCornerPosition } from '../utilities/coordinates';
 
-import { Box } from './utils';
-
-export type ActionType = 'resizing' | 'moving' | 'drawing' | 'idle';
+import { Box, CommittedBox } from './utils';
 
 export interface ResizeAction {
   /**
@@ -71,22 +69,5 @@ export interface Roi<TData = unknown> extends Box {
   data?: TData;
 }
 
-export interface CommittedRoi<TData = unknown>
-  extends Omit<Roi<TData>, 'action' | 'x1' | 'x2' | 'y1' | 'y2'> {
-  /**
-   * Left position of the ROI box relatively to the viewport of the target. The value is in the [0, 1] domain.
-   */
-  x: number;
-  /**
-   * Top position of the ROI box relatively to the viewport of the target. The value is in the [0, 1] domain.
-   */
-  y: number;
-  /**
-   * Width of the ROI box relatively to the viewport of the target. The value is in the [0, 1] domain.
-   */
-  width: number;
-  /**
-   * Height of the ROI box relatively to the viewport of the target. The value is in the [0, 1] domain.
-   */
-  height: number;
-}
+export type CommittedRoi<TData = unknown> = Omit<Roi<TData>, 'action'> &
+  CommittedBox;

--- a/src/utilities/coordinates.ts
+++ b/src/utilities/coordinates.ts
@@ -24,7 +24,7 @@ export function normalizeBox<T extends Box>(box: T): CommittedBox {
     width,
     height,
     angle,
-  } as CommittedBox;
+  };
 }
 
 export function denormalizeBox<T extends CommittedBox>(position: T): Box {
@@ -42,7 +42,7 @@ export function denormalizeBox<T extends CommittedBox>(position: T): Box {
     width,
     height,
     angle,
-  } as Box;
+  };
 }
 
 export function commitBox(

--- a/src/utilities/rois.ts
+++ b/src/utilities/rois.ts
@@ -1,10 +1,10 @@
-import { ReactRoiState } from '../context/roiReducer';
-import { boundRoi, BoundStrategy } from '../context/updaters/roi';
+import { CommitBoxStrategy, ReactRoiState } from '../context/roiReducer';
+import { boundBox, BoundStrategy } from '../context/updaters/roi';
 import { CommittedBox, Size } from '../index';
 import { CommittedRoi, Roi } from '../types/Roi';
 
 import { assert } from './assert';
-import { denormalizeBox, normalizeBox } from './coordinates';
+import { commitBox, denormalizeBox, normalizeBox } from './coordinates';
 
 function createInitialCommittedBox(): CommittedBox {
   return {
@@ -47,11 +47,16 @@ export function createCommittedRoiFromRoi<T>(
   roi: Roi<T>,
   targetSize: Size,
   strategy: BoundStrategy,
+  commitStrategy: CommitBoxStrategy,
 ): CommittedRoi<T> {
   const { action, ...obj } = roi;
   return {
     ...obj,
-    ...boundRoi(normalizeBox(roi), targetSize, strategy),
+    ...boundBox(
+      commitBox(normalizeBox(roi), roi.action, commitStrategy),
+      targetSize,
+      strategy,
+    ),
   };
 }
 
@@ -62,11 +67,13 @@ export function createCommittedRoiFromRoiIfValid<T>(
     minNewRoiSize: number;
   },
   boundStrategy: BoundStrategy,
+  commitStrategy: CommitBoxStrategy,
 ): CommittedRoi<T> | null {
   const newCommittedRoi = createCommittedRoiFromRoi(
     roi,
     options.targetSize,
     boundStrategy,
+    commitStrategy,
   );
   if (
     newCommittedRoi.width < options.minNewRoiSize ||

--- a/src/utilities/rois.ts
+++ b/src/utilities/rois.ts
@@ -43,12 +43,16 @@ export function createRoi(
   };
 }
 
+interface CreateCommittedRoiFromRoiOptions {
+  targetSize: Size;
+  strategy: BoundStrategy;
+  commitStrategy: CommitBoxStrategy;
+}
 export function createCommittedRoiFromRoi<T>(
   roi: Roi<T>,
-  targetSize: Size,
-  strategy: BoundStrategy,
-  commitStrategy: CommitBoxStrategy,
+  options: CreateCommittedRoiFromRoiOptions,
 ): CommittedRoi<T> {
+  const { targetSize, strategy, commitStrategy } = options;
   const { action, ...obj } = roi;
   return {
     ...obj,
@@ -62,19 +66,9 @@ export function createCommittedRoiFromRoi<T>(
 
 export function createCommittedRoiFromRoiIfValid<T>(
   roi: Roi<T>,
-  options: {
-    targetSize: Size;
-    minNewRoiSize: number;
-  },
-  boundStrategy: BoundStrategy,
-  commitStrategy: CommitBoxStrategy,
+  options: CreateCommittedRoiFromRoiOptions & { minNewRoiSize: number },
 ): CommittedRoi<T> | null {
-  const newCommittedRoi = createCommittedRoiFromRoi(
-    roi,
-    options.targetSize,
-    boundStrategy,
-    commitStrategy,
-  );
+  const newCommittedRoi = createCommittedRoiFromRoi(roi, options);
   if (
     newCommittedRoi.width < options.minNewRoiSize ||
     newCommittedRoi.height < options.minNewRoiSize

--- a/stories/misc/commit-strategy.stories.tsx
+++ b/stories/misc/commit-strategy.stories.tsx
@@ -1,0 +1,48 @@
+import { Meta } from '@storybook/react';
+
+import { RoiContainer, RoiList, RoiProvider, TargetImage } from '../../src';
+import { CommitBoxStrategy } from '../../src/context/roiReducer';
+import { CommittedRoisButton } from '../utils/CommittedRoisButton';
+import { Layout } from '../utils/Layout';
+import { getInitialRois } from '../utils/initialRois';
+
+export default {
+  title: 'Misc',
+  args: {
+    commitStrategy: 'exact',
+    allowRotate: false,
+  },
+  argTypes: {
+    commitStrategy: {
+      options: ['exact', 'round'] as const satisfies CommitBoxStrategy[],
+      control: {
+        type: 'select',
+      },
+    },
+  },
+} as Meta;
+
+export function CommitStrategy(props: {
+  commitStrategy: CommitBoxStrategy;
+  allowRotate: boolean;
+}) {
+  const initialRois = getInitialRois(320, 320);
+  return (
+    <RoiProvider
+      key={props.commitStrategy}
+      initialConfig={{
+        rois: initialRois,
+        commitRoiBoxStrategy: props.commitStrategy,
+      }}
+    >
+      <Layout>
+        <RoiContainer
+          target={<TargetImage id="story-image" src="/barbara.jpg" />}
+        >
+          <RoiList allowRotate={props.allowRotate} />
+        </RoiContainer>
+      </Layout>
+      <CommittedRoisButton showImage={false} />
+    </RoiProvider>
+  );
+}

--- a/stories/utils/CommittedRoisButton.tsx
+++ b/stories/utils/CommittedRoisButton.tsx
@@ -3,7 +3,8 @@ import { useEffect, useReducer, useRef } from 'react';
 
 import { useCommittedRois } from '../../src';
 
-export function CommittedRoisButton() {
+export function CommittedRoisButton(props: { showImage?: boolean }) {
+  const { showImage = true } = props;
   const ref = useRef<HTMLCanvasElement>(null);
   const rois = useCommittedRois();
   const [isShown, show] = useReducer((s) => !s, false);
@@ -45,7 +46,13 @@ export function CommittedRoisButton() {
       </button>
       {isShown && (
         <>
-          <canvas ref={ref} id="transformed-image" style={{ maxWidth: 400 }} />
+          {showImage && (
+            <canvas
+              ref={ref}
+              id="transformed-image"
+              style={{ maxWidth: 400 }}
+            />
+          )}
           <pre>{JSON.stringify(rois, null, 2)}</pre>
         </>
       )}


### PR DESCRIPTION
For non-rotated rois, all box properties will be integers
For rotated rois, only width and height will be integers