### PR TITLE
fix: don't update on mouse up if roi state is idle

### DIFF
--- a/src/context/updaters/endAction.ts
+++ b/src/context/updaters/endAction.ts
@@ -13,7 +13,7 @@ export function endAction(draft: ReactRoiState, payload: EndActionPayload) {
   const committedRoi = committedRois.find((roi) => roi.id === selectedRoi);
 
   if (!roi) return;
-
+  if (roi.action.type === 'idle') return;
   if (committedRoi) {
     assert(
       roi.action.type !== 'drawing',


### PR DESCRIPTION
This can lead to a bug in an edge case when end action is called before the dimensions of the container or target are defined
