### PR TITLE
fix: better shadow size

### DIFF
--- a/src/components/box/RoiBox.tsx
+++ b/src/components/box/RoiBox.tsx
@@ -74,7 +74,7 @@ function RoiBoxInternal(props: RoiBoxProps): JSX.Element {
           height: box.height,
           boxShadow:
             isSelected && shadowOpacity
-              ? `0 0 0 ${Math.max(panzoom.containerSize.width * totalPanzoom.scale * 2, panzoom.containerSize.height * totalPanzoom.scale * 2)}px rgba(0,0,0,${shadowOpacity})`
+              ? `0 0 0 ${Math.max(panzoom.containerSize.width * 4, panzoom.containerSize.height * 4)}px rgba(0,0,0,${shadowOpacity})`
               : 'none',
         }}
       >


### PR DESCRIPTION
Closes: https://github.com/zakodium-oss/react-roi/issues/135

fixes a bug where it is too small when the target image has to be scaled down
