### PR TITLE
fix: export usePanZoomTransform

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,5 +13,6 @@ export * from './hooks/useActions';
 export * from './hooks/useCommittedRois';
 export * from './hooks/useRoiState';
 export * from './hooks/useTargetRef';
+export { usePanZoomTransform } from './hooks/usePanZoom';
 
 export * from './libHelpers/image';


### PR DESCRIPTION
This is useful to apply the same transform as on the target to other elements, for example children of `RoiContainer`.