### PR TITLE
fix: target and container size initialization order should not affect base transform calculations

### DIFF
--- a/src/context/RoiProvider.tsx
+++ b/src/context/RoiProvider.tsx
@@ -81,6 +81,7 @@ export interface RoiProviderInitialConfig<TData> {
    *            scaled at all if the target is smaller than the container. The center of the target matches the center
    *            of the container.
    * - `center`: The center of the target matches the center of the container, without scaling the target.
+   * @default 'contain'
    */
   resizeStrategy?: ResizeStrategy;
   /**

--- a/src/context/RoiProvider.tsx
+++ b/src/context/RoiProvider.tsx
@@ -71,6 +71,17 @@ export interface RoiProviderInitialConfig<TData> {
    * @default 'inside_auto'
    */
   commitRoiBoundaryStrategy?: BoundaryStrategy;
+  /**
+   * Defines how the target should fit within the container at initialization.
+   * - `none`: The target is not transformed relative to the container. The top-left corner of the target matches the
+   *           top-left corner of the container.
+   * - `contain`: The target is transformed such as the full target is visible in the container. The center of the
+   *              target matches the center of the container.
+   * - `cover`: The target is scaled down such that one of the dimensions is fitting the container exactly, or not
+   *            scaled at all if the target is smaller than the container. The center of the target matches the center
+   *            of the container.
+   * - `center`: The center of the target matches the center of the container, without scaling the target.
+   */
   resizeStrategy?: ResizeStrategy;
   /**
    * How should the roi be updated before committing it when created / moved / resized / rotated.
@@ -120,7 +131,8 @@ function createInitialState<T>(
   return {
     mode: initialConfig.mode,
     action: 'idle',
-    isInitialized: false,
+    isContainerInitialized: false,
+    isTargetInitialized: false,
     resizeStrategy: initialConfig.resizeStrategy,
     commitRoiBoxStrategy: initialConfig.commitRoiBoxStrategy,
     commitRoiBoundaryStrategy: initialConfig.commitRoiBoundaryStrategy,
@@ -219,7 +231,8 @@ export function RoiProvider<TData>(props: RoiProviderProps<TData>) {
     startPanZoom,
     targetSize,
     containerSize,
-    isInitialized,
+    isTargetInitialized,
+    isContainerInitialized,
     action,
   } = state;
   const roiState: RoiState = useMemo(() => {
@@ -230,6 +243,7 @@ export function RoiProvider<TData>(props: RoiProviderProps<TData>) {
     };
   }, [mode, selectedRoi, action]);
 
+  const isReady = isTargetInitialized && isContainerInitialized;
   const panzoomContextValue: PanZoomContext = useMemo(() => {
     return {
       targetSize,
@@ -238,16 +252,9 @@ export function RoiProvider<TData>(props: RoiProviderProps<TData>) {
       basePanZoom,
       startPanZoom,
       // We memoize this here to minimize the number of times we need to render the container
-      isReady: isInitialized,
+      isReady,
     };
-  }, [
-    panZoom,
-    basePanZoom,
-    startPanZoom,
-    isInitialized,
-    targetSize,
-    containerSize,
-  ]);
+  }, [panZoom, basePanZoom, startPanZoom, isReady, targetSize, containerSize]);
 
   return (
     <callbacksRefContext.Provider value={callbacksRef}>

--- a/src/context/updaters/initialPanZoom.ts
+++ b/src/context/updaters/initialPanZoom.ts
@@ -10,11 +10,11 @@ export const initialSize: Size = {
   height: 1,
 };
 
+/**
+ * Updates the base transform which places the target relative to the container.
+ * This should only be called once both the target and container sizes are known.
+ */
 export function updateBasePanZoom(draft: Draft<ReactRoiState>) {
-  if (!draft.isInitialized) {
-    return;
-  }
-
   switch (draft.resizeStrategy) {
     case 'contain':
       updateBasePanZoomContain(draft);

--- a/src/hooks/useTargetRef.ts
+++ b/src/hooks/useTargetRef.ts
@@ -11,7 +11,7 @@ export function useTargetRef<T extends HTMLElement>() {
   // @ts-expect-error This can be ignored for now
   useResizeObserver(targetRef, (data) => {
     roiDispatch({
-      type: 'SET_SIZE',
+      type: 'SET_TARGET_SIZE',
       payload: {
         width: data.contentRect.width,
         height: data.contentRect.height,

--- a/stories/8-edge-cases/initial-config-zoom.stories.tsx
+++ b/stories/8-edge-cases/initial-config-zoom.stories.tsx
@@ -1,0 +1,104 @@
+import type { Meta } from '@storybook/react-vite';
+import type { PropsWithChildren } from 'react';
+
+import {
+  RoiContainer,
+  RoiList,
+  RoiProvider,
+  TargetImage,
+  getTargetImageStyle,
+  useTargetRef,
+} from '../../src/index.ts';
+
+export default {
+  title: 'Edge cases > zoom',
+  decorators: (Story) => {
+    return (
+      <AppLayout>
+        <Story />
+      </AppLayout>
+    );
+  },
+} as Meta;
+
+function AppLayout(props: PropsWithChildren) {
+  return (
+    <div
+      style={{
+        height: '75vh',
+        // background: '#f5f5f5',
+        border: 'solid 1px black',
+      }}
+    >
+      {props.children}
+    </div>
+  );
+}
+
+export function NoConfigWithTargetImage() {
+  return (
+    <RoiProvider>
+      <RoiContainer
+        target={<TargetImage src="/barbara.jpg" />}
+        style={{ height: '100%' }}
+      >
+        <RoiList />
+      </RoiContainer>
+    </RoiProvider>
+  );
+}
+
+export function InitialConfigZoomWithTargetImage() {
+  return (
+    <RoiProvider
+      initialConfig={{ zoom: { initial: { origin: 'center', scale: 0.8 } } }}
+    >
+      <RoiContainer
+        target={<TargetImage src="/barbara.jpg" />}
+        style={{ height: '100%' }}
+      >
+        <RoiList />
+      </RoiContainer>
+    </RoiProvider>
+  );
+}
+
+// when we use image with ref from useTargetRef it's broken
+export function NoConfigWithoutTargetImage() {
+  return (
+    <RoiProvider>
+      <Container />
+    </RoiProvider>
+  );
+}
+
+// when we use image with ref from useTargetRef it's broken
+export function InitialConfigZoomWithoutTargetImage() {
+  return (
+    <RoiProvider
+      initialConfig={{ zoom: { initial: { origin: 'center', scale: 0.8 } } }}
+    >
+      <Container />
+    </RoiProvider>
+  );
+}
+
+function Container() {
+  const ref = useTargetRef<HTMLImageElement>();
+
+  return (
+    <RoiContainer
+      target={
+        <img
+          ref={ref}
+          src="/barbara.jpg"
+          alt=""
+          style={getTargetImageStyle()}
+        />
+      }
+      style={{ height: '100%' }}
+    >
+      <RoiList />
+    </RoiContainer>
+  );
+}

--- a/stories/8-edge-cases/initial-config-zoom.stories.tsx
+++ b/stories/8-edge-cases/initial-config-zoom.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta } from '@storybook/react-vite';
 import type { PropsWithChildren } from 'react';
 
+import type { ResizeStrategy } from '../../src/index.ts';
 import {
   RoiContainer,
   RoiList,
@@ -9,6 +10,7 @@ import {
   getTargetImageStyle,
   useTargetRef,
 } from '../../src/index.ts';
+import { useResetOnChange } from '../utils/useResetOnChange.ts';
 
 export default {
   title: 'Edge cases > zoom',
@@ -18,6 +20,17 @@ export default {
         <Story />
       </AppLayout>
     );
+  },
+  args: {
+    resizeStrategy: 'contain',
+  },
+  argTypes: {
+    resizeStrategy: {
+      options: ['contain', 'cover', 'center', 'none'],
+      control: {
+        type: 'select',
+      },
+    },
   },
 } as Meta;
 
@@ -35,9 +48,15 @@ function AppLayout(props: PropsWithChildren) {
   );
 }
 
-export function NoConfigWithTargetImage() {
+export function NoConfigWithTargetImage(props: {
+  resizeStrategy: ResizeStrategy;
+}) {
+  const keyId = useResetOnChange([props.resizeStrategy]);
   return (
-    <RoiProvider>
+    <RoiProvider
+      key={keyId}
+      initialConfig={{ resizeStrategy: props.resizeStrategy }}
+    >
       <RoiContainer
         target={<TargetImage src="/barbara.jpg" />}
         style={{ height: '100%' }}
@@ -48,10 +67,17 @@ export function NoConfigWithTargetImage() {
   );
 }
 
-export function InitialConfigZoomWithTargetImage() {
+export function InitialConfigZoomWithTargetImage(props: {
+  resizeStrategy: ResizeStrategy;
+}) {
+  const keyId = useResetOnChange([props.resizeStrategy]);
   return (
     <RoiProvider
-      initialConfig={{ zoom: { initial: { origin: 'center', scale: 0.8 } } }}
+      key={keyId}
+      initialConfig={{
+        zoom: { initial: { origin: 'center', scale: 0.8 } },
+        resizeStrategy: props.resizeStrategy,
+      }}
     >
       <RoiContainer
         target={<TargetImage src="/barbara.jpg" />}
@@ -64,19 +90,32 @@ export function InitialConfigZoomWithTargetImage() {
 }
 
 // when we use image with ref from useTargetRef it's broken
-export function NoConfigWithoutTargetImage() {
+export function NoConfigWithoutTargetImage(props: {
+  resizeStrategy: ResizeStrategy;
+}) {
+  const keyId = useResetOnChange([props.resizeStrategy]);
   return (
-    <RoiProvider>
+    <RoiProvider
+      key={keyId}
+      initialConfig={{ resizeStrategy: props.resizeStrategy }}
+    >
       <Container />
     </RoiProvider>
   );
 }
 
 // when we use image with ref from useTargetRef it's broken
-export function InitialConfigZoomWithoutTargetImage() {
+export function InitialConfigZoomWithoutTargetImage(props: {
+  resizeStrategy: ResizeStrategy;
+}) {
+  const keyId = useResetOnChange([props.resizeStrategy]);
   return (
     <RoiProvider
-      initialConfig={{ zoom: { initial: { origin: 'center', scale: 0.8 } } }}
+      key={keyId}
+      initialConfig={{
+        zoom: { initial: { origin: 'center', scale: 0.8 } },
+        resizeStrategy: props.resizeStrategy,
+      }}
     >
       <Container />
     </RoiProvider>


### PR DESCRIPTION
https://repro-scale-issue.react-roi.pages.dev/?path=%2Fstory%2Fedge-cases-zoom--no-config-without-target-image

https://repro-scale-issue.react-roi.pages.dev/?path=%2Fstory%2Fedge-cases-zoom--initial-config-zoom-without-target-image